### PR TITLE
Support for SAP annotations for OData v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ parse(xml)
   .then(swagger => console.log(JSON.stringify(swagger, null, 2)))
   .catch(error => console.error(error))
 ```
+
+
+## Support
+Support for a limited subset of SAP Annotations for OData v2 http://www.sap.com/Protocols/SAPData .

--- a/src/EntityProperty.ts
+++ b/src/EntityProperty.ts
@@ -2,6 +2,7 @@ export interface EntityProperty {
   name: string;
   type?: string;
   required?: boolean;
+  description?: string;  
   items?: any;
   $ref?: any;
   enum?: Array<any>;

--- a/src/EntitySet.ts
+++ b/src/EntitySet.ts
@@ -1,8 +1,10 @@
 import { EntityType } from './EntityType';
+import { FunctionImport } from './FunctionImport';
 
 export interface EntitySet {
   name: string;
   entityType: EntityType;
   namespace: string;
   annotations?: Array<string>;
+  functionImports?: Array<FunctionImport>;
 }

--- a/src/FunctionImport.ts
+++ b/src/FunctionImport.ts
@@ -1,0 +1,11 @@
+import { ReturnType } from './ReturnType';
+import { Parameter } from './Parameter';
+
+export interface FunctionImport {
+  name: string;
+  label: string;
+  httpMethod: string;
+  parameters?: Array<Parameter>;
+  entitySet?: string;
+  returnType: ReturnType;
+}

--- a/src/Operation.ts
+++ b/src/Operation.ts
@@ -6,4 +6,6 @@ export interface Operation {
   operationId: string;
   parameters?: Array<Parameter>;
   responses: Responses;
+  description?:string;
+  summary?:string;
 }

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -16,4 +16,6 @@ export interface Options {
   functions?:  Array<Function>;
   enumTypes?: Array<EnumType>;
   defaultNamespace?: string;
+  schemes?: Array<string>;
+  title?: string;
 }

--- a/src/Property.ts
+++ b/src/Property.ts
@@ -5,6 +5,7 @@ export interface Property {
   type: string;
   enum?: Array<any>;
   format?: string;
+  description?: string;    
   minimum?: number;
   maximum?: number;
   default?: any;

--- a/src/SAPData/SAPEntityProperty.ts
+++ b/src/SAPData/SAPEntityProperty.ts
@@ -1,0 +1,17 @@
+import { EntityProperty } from '../EntityProperty';
+
+//Additional attributes from https://wiki.scn.sap.com/wiki/display/EmTech/SAP+Annotations+for+OData+Version+2.0#SAPAnnotationsforODataVersion2.0-Elementedm:Property
+export interface SAPEntityProperty extends EntityProperty {
+    creatable: boolean;
+    updatable: boolean;
+    deleteable: boolean;
+    pageable: boolean;
+    filterable: boolean;
+    sortable: boolean;
+    label?: string;
+}
+
+//Simple instanceof replacement as we're not working with classes
+export function instanceOfSAPEntityProperty(object:EntityProperty){
+    return 'creatable' in object; 
+}

--- a/src/SAPData/SAPEntitySet.ts
+++ b/src/SAPData/SAPEntitySet.ts
@@ -1,0 +1,16 @@
+import { EntitySet } from '../EntitySet';
+
+//Additional attributes from https://wiki.scn.sap.com/wiki/display/EmTech/SAP+Annotations+for+OData+Version+2.0#SAPAnnotationsforODataVersion2.0-Elementedm:EntitySet
+export interface SAPEntitySet extends EntitySet {
+    creatable: boolean;
+    updatable: boolean;
+    deleteable: boolean;
+    pageable: boolean;
+    searchable: boolean;    
+    label?: string;
+}
+
+//Simple instanceof replacement as we're not working with classes
+export function instanceOfSAPEntitySet(object:EntitySet){
+    return 'creatable' in object; 
+}

--- a/src/SAPData/SAPFunction.ts
+++ b/src/SAPData/SAPFunction.ts
@@ -1,0 +1,12 @@
+import { Function } from '../Function';
+import { EntityType } from '../EntityType';
+
+export interface SAPFunction extends Function{
+    label?: string;
+    actionFor: string;
+}
+
+//Simple instanceof replacement as we're not working with classes
+export function instanceOfSAPFunction(object:Function){
+    return 'actionFor' in object; 
+}


### PR DESCRIPTION
http://www.sap.com/Protocols/SAPData

SAP is using OData heavily for exposing APIs. For OData v2, SAP has provided their own extensions.
For OData v4 these extensions are mostly added to the Oasis standard.

Features support include:
-Detect SAP specific additions based on xmlNamespace
-Define operations based on EntitySet sap metadata (creatable, updatable etc)
-Include user friendly description pr property
-FunctionImport support
-List out expandable properties

In addition, added optional Options.schemes and Options.title properties.