### PR TITLE
fix: ensure that generated dts is compatible with --strictNullChecks

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "rm -rf dist && mkdir dist && tsc --declaration --outDir dist --rootDir src",
     "build:example": "rm -rf dist && mkdir dist && tsc --declaration --outDir dist --project example.tsconfig.json",
     "start": "npm run build:example && node dist/example/index.js",
-    "prepublish": "npm run build"
+    "test": "tsc --noEmit --strictNullChecks test/index.ts --moduleResolution node",
+    "prepublish": "npm run build && npm test"
   },
   "repository": {
     "type": "git",

--- a/src/Responses.ts
+++ b/src/Responses.ts
@@ -3,5 +3,5 @@ import { Reference } from './Reference';
 
 export interface Responses {
   default?: Response | Reference;
-  [httpStatusCode: string]: Response | Reference;
+  [httpStatusCode: string]: Response | Reference | undefined;
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,1 @@
+import {odata2openapi} from '../dist'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
   },
   "exclude": [
     "dist",
+    "test",
     "node_modules",
     "example"
   ]


### PR DESCRIPTION
Updates src/Responses.ts to ensure compatibility with --strictNullChecks

Without this change, when using this library with --strictNullChecks, typescript will throw the build error:

```
dist/Responses.d.ts(4,5): error TS2411: Property 'default' of type 'Reference | Response | undefined' is not assignable to string index type 'Reference | Response'.
```